### PR TITLE
Avoid attribute collision with other projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ for example, the default style:
 	        custom:progress_text_offset="1dp"
 	        custom:progress_text_visibility="visible"
 	        
-	        custom:max="100"
-	        custom:progress="80"
+	        custom:progress_max="100"
+	        custom:progress_curent="80"
 	         />
 ```
 

--- a/demo/src/main/res/layout/activity_main.xml
+++ b/demo/src/main/res/layout/activity_main.xml
@@ -16,7 +16,7 @@
         android:id="@+id/numberbar1"
         android:layout_width="wrap_content"
         android:padding="20dp"
-        custom:progress="0"
+        custom:progress_current="0"
         style="@style/NumberProgressBar_Default"
         android:layout_height="wrap_content" />
 
@@ -24,7 +24,7 @@
         android:id="@+id/numberbar2"
         android:layout_height="wrap_content"
         android:padding="20dp"
-        custom:progress="20"
+        custom:progress_current="20"
         android:layout_width="match_parent"
         style="@style/NumberProgressBar_Passing_Green"
      />
@@ -33,7 +33,7 @@
         android:id="@+id/numberbar3"
         android:layout_margin="20dp"
         style="@style/NumberProgressBar_Relax_Blue"
-        custom:progress="30"
+        custom:progress_current="30"
         android:layout_height="wrap_content" />
 
     <com.daimajia.numberprogressbar.NumberProgressBar
@@ -41,7 +41,7 @@
         android:layout_width="wrap_content"
         android:layout_margin="20dp"
         style="@style/NumberProgressBar_Grace_Yellow"
-        custom:progress="40"
+        custom:progress_current="40"
         android:layout_height="wrap_content" />
 
 
@@ -49,7 +49,7 @@
         android:id="@+id/numberbar5"
         android:layout_width="wrap_content"
         android:layout_margin="20dp"
-        custom:progress="50"
+        custom:progress_current="50"
         style="@style/NumberProgressBar_Warning_Red"
         android:layout_height="wrap_content" />
 
@@ -59,7 +59,7 @@
         android:layout_width="wrap_content"
         android:layout_margin="20dp"
         style="@style/NumberProgressBar_Funny_Orange"
-        custom:progress="60"
+        custom:progress_current="60"
         android:layout_height="wrap_content" />
 
     <com.daimajia.numberprogressbar.NumberProgressBar
@@ -67,7 +67,7 @@
         android:layout_width="wrap_content"
         android:layout_margin="20dp"
         style="@style/NumberProgressBar_Beauty_Red"
-        custom:progress="70"
+        custom:progress_current="70"
         android:layout_height="wrap_content" />
 
     <com.daimajia.numberprogressbar.NumberProgressBar
@@ -75,7 +75,7 @@
         android:layout_width="wrap_content"
         android:layout_margin="20dp"
         style="@style/NumberProgressBar_Twinkle_Night"
-        custom:progress="80"
+        custom:progress_current="80"
         android:layout_height="wrap_content" />
 
 </LinearLayout>

--- a/library/src/main/java/com/daimajia/numberprogressbar/NumberProgressBar.java
+++ b/library/src/main/java/com/daimajia/numberprogressbar/NumberProgressBar.java
@@ -193,8 +193,8 @@ public class NumberProgressBar extends View {
             mIfDrawText = false;
         }
 
-        setProgress(attributes.getInt(R.styleable.NumberProgressBar_progress, 0));
-        setMax(attributes.getInt(R.styleable.NumberProgressBar_max, 100));
+        setProgress(attributes.getInt(R.styleable.NumberProgressBar_progress_current, 0));
+        setMax(attributes.getInt(R.styleable.NumberProgressBar_progress_max, 100));
 
         attributes.recycle();
         initializePainters();

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="NumberProgressBar">
-        <attr name="progress" format="integer"/>
-        <attr name="max" format="integer"/>
+        <attr name="progress_current" format="integer"/>
+        <attr name="progress_max" format="integer"/>
 
         <attr name="progress_unreached_color" format="color"/>
         <attr name="progress_reached_color" format="color"/>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -4,8 +4,8 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_width">match_parent</item>
 
-        <item name="max">100</item>
-        <item name="progress">0</item>
+        <item name="progress_max">100</item>
+        <item name="progress_current">0</item>
 
         <item name="progress_unreached_color">#CCCCCC</item>
         <item name="progress_reached_color">#3498DB</item>
@@ -21,8 +21,8 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_width">match_parent</item>
 
-        <item name="max">100</item>
-        <item name="progress">0</item>
+        <item name="progress_max">100</item>
+        <item name="progress_current">0</item>
 
         <item name="progress_unreached_color">#CCCCCC</item>
         <item name="progress_reached_color">#70A800</item>
@@ -38,8 +38,8 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_width">match_parent</item>
 
-        <item name="max">100</item>
-        <item name="progress">0</item>
+        <item name="progress_max">100</item>
+        <item name="progress_current">0</item>
 
         <item name="progress_unreached_color">#CCCCCC</item>
         <item name="progress_reached_color">#FF3D7F</item>
@@ -54,8 +54,8 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_width">match_parent</item>
 
-        <item name="max">100</item>
-        <item name="progress">0</item>
+        <item name="progress_max">100</item>
+        <item name="progress_current">0</item>
 
         <item name="progress_unreached_color">#CCCCCC</item>
         <item name="progress_reached_color">#E74C3C</item>
@@ -70,8 +70,8 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_width">match_parent</item>
 
-        <item name="max">100</item>
-        <item name="progress">0</item>
+        <item name="progress_max">100</item>
+        <item name="progress_current">0</item>
 
         <item name="progress_unreached_color">#CCCCCC</item>
         <item name="progress_reached_color">#6DBCDB</item>
@@ -86,8 +86,8 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_width">match_parent</item>
 
-        <item name="max">100</item>
-        <item name="progress">0</item>
+        <item name="progress_max">100</item>
+        <item name="progress_current">0</item>
 
         <item name="progress_unreached_color">#CCCCCC</item>
         <item name="progress_reached_color">#FFC73B</item>
@@ -102,8 +102,8 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_width">match_parent</item>
 
-        <item name="max">100</item>
-        <item name="progress">0</item>
+        <item name="progress_max">100</item>
+        <item name="progress_current">0</item>
 
         <item name="progress_unreached_color">#CCCCCC</item>
         <item name="progress_reached_color">#FF530D</item>
@@ -118,8 +118,8 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_width">match_parent</item>
 
-        <item name="max">100</item>
-        <item name="progress">0</item>
+        <item name="progress_max">100</item>
+        <item name="progress_current">0</item>
 
         <item name="progress_unreached_color">#CCCCCC</item>
         <item name="progress_reached_color">#ECF0F1</item>


### PR DESCRIPTION
There are a couple attributes that are generic and could and will collide with other projects: `max` and `progress`. This would make the project throw compile errors.

Here's a well know library that has these two attributes defined:
https://github.com/navasmdc/MaterialDesignLibrary
- https://github.com/navasmdc/MaterialDesignLibrary/blob/master/MaterialDesign/res/values/attributes.xml#L19
- https://github.com/navasmdc/MaterialDesignLibrary/blob/master/MaterialDesign/res/values/attributes.xml#L13