### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ BTW. My friends also made some other platform's NumberProgressBar：
 
 ```groovy
 dependencies {
-   compile 'com.daimajia.numberprogressbar:library:1.4@aar'
+   implementation 'com.daimajia.numberprogressbar:library:1.4@aar'
 }
 ```
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.